### PR TITLE
Add vikunja-link: auto-link/close Vikunja tasks from PRs

### DIFF
--- a/.github/workflows/vikunja-link-caller.yml
+++ b/.github/workflows/vikunja-link-caller.yml
@@ -1,0 +1,14 @@
+name: Vikunja Link (this repo)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  vikunja-link:
+    # environment: lives on the reusable workflow's own job (vikunja-link.yml),
+    # not here — GitHub's schema doesn't allow `environment:` on a job that
+    # also has `uses:`. secrets: inherit still passes environment secrets
+    # through once the callee's job requests that environment itself.
+    uses: JoaquimFontesMatos/claude-skills/.github/workflows/vikunja-link.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
Calls the reusable vikunja-link workflow in claude-skills (Vikunja task #112) to auto-link/close Vikunja tasks referenced in this repo's PRs.

## Not yet functional
Needs, before this actually does anything on a real PR:
- A `vikunja-link` GitHub Environment on this repo (already created, empty) populated with `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`, `VIKUNJA_API_TOKEN` — same values already used in claude-skills, safe to reuse across repos.
- The Vikunja bot user shared with the **Gymrat** Vikunja project (id 4).

## Test plan
- [ ] Populate the environment secrets and share the bot with the Gymrat project.
- [ ] Open a throwaway PR referencing a real Gymrat-project Vikunja task to confirm it links/closes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)