### PR TITLE
Remove leftover scratch file from vikunja-link rollout retest

### DIFF
--- a/vikunja-link-rollout-test-2.md
+++ b/vikunja-link-rollout-test-2.md
@@ -1,1 +1,0 @@
-Scratch file for vikunja-link rollout retest.


### PR DESCRIPTION
Cleanup: removes the scratch `.md` file used to trigger the vikunja-link rollout retest PR.