### PR TITLE
doc-drift: document missing just recipe in CLAUDE.md (2026-07-26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Local dev runs through the `justfile`, which wraps `mix` with `infisical run --e
 - `just run` — run the app at `localhost:4000` (`mix phx.server`)
 - `just iex` — start an IEx session (`iex -S mix`)
 - `just test` — run tests under `MIX_ENV=test`
+- `just db-migrate-prod` — run production DB migrations (`MIX_ENV=prod`, Infisical `prod` env)
 
 No `just` recipe exists for these yet — run them via `mix` (wrap with `infisical run --env=dev -- …` if they need secrets):
 


### PR DESCRIPTION
## Summary
Found by the automated doc-drift audit: CLAUDE.md's Commands section explicitly tracks which `just` recipes exist vs. which don't (it says "No just recipe exists for these yet" for anything missing), but `justfile`'s `db-migrate-prod` recipe was in neither list. Added it.

Deliberately worded without asserting anything about which DB backs prod — `justfile`'s own comment on that recipe says "(Aiven)" but that claim looks stale (the app moved to a Docker/GHCR + ArgoCD homelab deployment after that comment was written) and is being tracked separately as a Vikunja task rather than guessed at here.

## Test plan
- Docs-only change, no code edits.

🤖 Generated by the doc-drift skill.